### PR TITLE
Fix: stretch & scale on resize

### DIFF
--- a/game/project.godot
+++ b/game/project.godot
@@ -19,6 +19,7 @@ config/icon="res://icon.svg"
 
 window/size/viewport_width=1280
 window/size/viewport_height=720
+window/stretch/mode="canvas_items"
 
 [gui]
 


### PR DESCRIPTION
previous behavior would just extend the boundaries of the rendering window to show stuff that wasn't meant to be onscreen - oopsie